### PR TITLE
Add CI workflow and project docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+/apps/badge-server/ @bogdancazacu
+/specs/badge-spec/ @bogdancazacu
+/registry/vendor-registry/ @bogdancazacu
+/tools/tooling/ @bogdancazacu
+/docs/ @bogdancazacu
+/website/ @bogdancazacu

--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -1,0 +1,53 @@
+name: Monorepo CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cd docs/docs-site && npm ci && npm run build
+
+  build-website:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cd website && npm ci && npm run build
+
+  lint-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: cd tools/tooling && pip install -r requirements.txt && flake8 . && black --check .
+
+  test-tooling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: cd tools/tooling && pip install -r requirements.txt && pytest
+
+  validate-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: python tools/tooling/validate_vendor_registry.py registry/vendor-registry/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Node.js
+node_modules/
+dist/
+.vitepress/dist/
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+.env
+
+# General
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# OpenAuthCert Monorepo
+
+This repository contains all core components of the **Open Authentication Certification Initiative**. It hosts the code for the badge server API, vendor registry, documentation website and various tooling.
+
+## Repository Structure
+
+- `/apps/badge-server` - Badge API
+- `/specs/badge-spec` - JSON/YAML badge definitions
+- `/registry/vendor-registry` - Certified vendors
+- `/tools/tooling` - Python CLI & validation tools
+- `/docs/docs-site` - VitePress docs site
+- `/website` - Public marketing site
+
+## Building and Testing
+
+For the documentation site and marketing website:
+
+```bash
+npm install && npm run build
+```
+
+For the Python tooling:
+
+```bash
+pip install -r requirements.txt && pytest
+```
+
+Visit the live site at [https://openauthcert.org](https://openauthcert.org).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "openauthcert-monorepo",
+  "private": true,
+  "scripts": {
+    "build-docs": "vitepress build docs/docs-site",
+    "build-website": "vitepress build website"
+  },
+  "devDependencies": {
+    "vitepress": "^1.0.0"
+  }
+}

--- a/tools/tooling/requirements.txt
+++ b/tools/tooling/requirements.txt
@@ -1,0 +1,3 @@
+.[test]
+flake8
+black


### PR DESCRIPTION
## Summary
- set CODEOWNERS for repo areas
- add main GitHub Actions workflow
- create repository README and .gitignore
- add root `package.json` for VitePress sites
- specify Python requirements for tooling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `flake8 .` *(fails: E501 line too long)*
- `black --check .` *(fails: would reformat files)*
- `npm install`
- `npm run build-docs` *(output truncated)*
- `npm run build-website` *(output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68570a9b07f083238401d9f170f7d91d