### PR TITLE
Codex/build vitepress website for openauthcert

### DIFF
--- a/apps/badge-server/main.py
+++ b/apps/badge-server/main.py
@@ -113,7 +113,7 @@ async def issue_badge(badge_in: BadgeIn) -> Badge:
     if badge_in.status == "revoked" and not badge_in.revoked_at:
         raise HTTPException(status_code=400, detail="revoked_at required when status is revoked")
     issued_at = badge_in.issued_at or _utcnow()
-    payload: Dict[str, object] = badge_in.model_dump()
+    payload: Dict[str, object] = badge_in.model_dump(mode="json")
     payload["issued_at"] = issued_at
     signature = _sign_badge(payload)
     badge = Badge(**payload, digital_signature=signature)
@@ -124,7 +124,7 @@ async def issue_badge(badge_in: BadgeIn) -> Badge:
 
 @app.post("/verify", response_model=Badge)
 async def verify_badge(badge: Badge) -> Badge:
-    _verify_badge(badge.model_dump())
+    _verify_badge(badge.model_dump(mode="json"))
     return badge
 
 
@@ -134,7 +134,7 @@ async def revoke_badge(request: RevokeRequest) -> Badge:
     existing = BADGE_STORE.get(key)
     if not existing:
         raise HTTPException(status_code=404, detail="Badge not found")
-    payload = existing.model_dump()
+    payload = existing.model_dump(mode="json")
     payload["status"] = "revoked"
     payload["revoked_at"] = _utcnow()
     if request.notes:

--- a/apps/badge-server/tests/test_main.py
+++ b/apps/badge-server/tests/test_main.py
@@ -84,3 +84,30 @@ def test_verify_and_revoke() -> None:
     revoked = revoke_response.json()
     assert revoked["status"] == "revoked"
     assert "revoked_at" in revoked
+
+
+def test_revoke_badge_preserves_evidence_urls() -> None:
+    client = TestClient(app)
+    payload = _issue_payload()
+    payload["evidence_urls"] = [
+        "https://example.com/evidence-1",
+        "https://example.com/evidence-2",
+    ]
+
+    issue_response = client.post("/issue", json=payload)
+    badge = issue_response.json()
+
+    revoke_response = client.post(
+        "/revoke",
+        json={
+            "vendor": badge["vendor"],
+            "application": badge["application"],
+            "version": badge["version"],
+        },
+    )
+    assert revoke_response.status_code == 200
+    revoked = revoke_response.json()
+    assert revoked["evidence_urls"] == payload["evidence_urls"]
+
+    verify_response = client.post("/verify", json=revoked)
+    assert verify_response.status_code == 200

--- a/apps/badge-server/tests/test_main.py
+++ b/apps/badge-server/tests/test_main.py
@@ -47,6 +47,22 @@ def test_issue_badge() -> None:
     assert base64.b64decode(data["digital_signature"])  # signature decodes
 
 
+def test_issue_badge_with_evidence_urls() -> None:
+    client = TestClient(app)
+    payload = _issue_payload()
+    payload["evidence_urls"] = [
+        "https://example.com/evidence-1",
+        "https://example.com/evidence-2",
+    ]
+    response = client.post("/issue", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["evidence_urls"] == payload["evidence_urls"]
+
+    verify_response = client.post("/verify", json=data)
+    assert verify_response.status_code == 200
+
+
 def test_verify_and_revoke() -> None:
     client = TestClient(app)
     issue_response = client.post("/issue", json=_issue_payload())


### PR DESCRIPTION
@codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evidence URLs provided when issuing a badge are now correctly returned in responses and remain intact through verification and after revocation.
  * Improved consistency of badge data across issue, verify, and revoke endpoints, ensuring reliable verification results.

* **Tests**
  * Added end-to-end tests validating evidence URL propagation during issue and verify flows.
  * Added tests confirming evidence URLs are preserved in responses after revocation and continue to verify successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->