### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-badges.yml
+++ b/.github/workflows/validate-badges.yml
@@ -1,4 +1,6 @@
 name: validate-badges
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/openauthcert/openauthcert/security/code-scanning/2](https://github.com/openauthcert/openauthcert/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to either the root of the workflow or specifically to the `validate` job so the GITHUB_TOKEN is restricted to only those permissions required for the job's steps. In this workflow, none of the steps need write access—they only read repository code and run validation. Therefore, the best fix is to add `permissions: contents: read` to the workflow root (just beneath the `name:` entry, before `on:`), which will apply to all jobs in the workflow by default. This change requires editing only the `.github/workflows/validate-badges.yml` file, with no imports or additional code definitions needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
