### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/badge-server-ci.yml
+++ b/.github/workflows/badge-server-ci.yml
@@ -1,4 +1,6 @@
 name: badge-server-ci
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/openauthcert/openauthcert/security/code-scanning/1](https://github.com/openauthcert/openauthcert/security/code-scanning/1)

To fix this issue, we need to add an explicit `permissions` block to the workflow (or job) YAML. Because the workflow simply installs dependencies and runs tests, and does not appear to need write access to the repository or other resources, we can set the minimal required scope: `contents: read`. To apply to all jobs, add the `permissions` block at the root level, just below `name:` (above `on:`), as per GitHub’s documentation. No other changes or imports are needed, just the addition of this explicit key-value mapping in your YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow permissions to explicitly grant read access to repository contents.
  * No changes to application features, user interface, or behavior.
  * Builds, tests, and deployment pipelines continue to run as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->