### PR TITLE
Expand navigation reach and clarify revoked badge notes

### DIFF
--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -45,7 +45,10 @@ export default defineConfig({
       { text: 'Overview', link: '/' },
       { text: 'Registry', link: '/registry' },
       { text: 'Verify', link: '/verify' },
-      { text: 'Spec', link: '/spec' }
+      { text: 'Spec', link: '/spec' },
+      { text: 'Apply', link: '/apply' },
+      { text: 'Governance', link: '/governance' },
+      { text: 'Trust', link: '/trust' }
     ],
     sidebar: {
       '/': [

--- a/website/docs/.vitepress/theme/components/BadgeCard.vue
+++ b/website/docs/.vitepress/theme/components/BadgeCard.vue
@@ -50,7 +50,10 @@ function formatDate(value: string) {
       </div>
     </dl>
 
-    <p v-if="badge.notes" class="badge-card__notes">{{ badge.notes }}</p>
+    <p v-if="badge.notes" class="badge-card__notes">
+      <span v-if="badge.revoked" class="badge-card__notes-label">Revocation note:</span>
+      <span>{{ badge.notes }}</span>
+    </p>
     <slot />
   </article>
 </template>
@@ -149,5 +152,13 @@ function formatDate(value: string) {
   border-left: 3px solid var(--vp-c-brand-1);
   background: var(--vp-c-bg-soft);
   color: var(--vp-c-text-1);
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.badge-card__notes-label {
+  font-weight: 700;
+  color: var(--vp-c-danger-1);
 }
 </style>

--- a/website/docs/.vitepress/theme/components/EvidenceLinks.vue
+++ b/website/docs/.vitepress/theme/components/EvidenceLinks.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { Badge } from '../../registry'
 
 const props = defineProps<{ badge: Badge }>()
 
-const localEvidencePath = `/registry/evidence/${props.badge.vendor}/${props.badge.application}/${props.badge.version}/`
+const localEvidencePath = computed(
+  () => `/registry/evidence/${props.badge.vendor}/${props.badge.application}/${props.badge.version}/`
+)
 </script>
 
 <template>

--- a/website/docs/.vitepress/theme/components/VerifyForm.vue
+++ b/website/docs/.vitepress/theme/components/VerifyForm.vue
@@ -34,8 +34,8 @@ async function verify() {
     const signature = base64ToBytes(signatureBase64)
     const key = await loadPublicKey()
     const encoder = new TextEncoder()
-    const valid = await globalThis.crypto!.subtle.verify(
-      'Ed25519',
+    const valid = await globalThis.crypto.subtle.verify(
+      { name: 'Ed25519' },
       key,
       signature,
       encoder.encode(canonical)

--- a/website/docs/registry.md
+++ b/website/docs/registry.md
@@ -7,10 +7,11 @@ import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vitepress'
 import RegistryList from './.vitepress/theme/components/RegistryList.vue'
 import RegistryFilters, { type RegistryQuery } from './.vitepress/theme/components/RegistryFilters.vue'
-import { facets, searchBadges } from './.vitepress/registry'
+import { facets, getAllBadges, searchBadges } from './.vitepress/registry'
 
 const pageSize = 20
 const facetData = facets()
+const initialCount = getAllBadges().length
 const query = ref<RegistryQuery>({})
 
 const sortOptions = [
@@ -173,6 +174,13 @@ function compareSemver(a: string, b: string) {
 
 The registry aggregates every badge defined in the repository. Use the filters to explore badges by vendor, application, badge type, and lifecycle state.
 
+<p class="registry-intro" v-if="initialCount > 0">
+  Currently tracking <strong>{{ initialCount }}</strong> badge<span v-if="initialCount !== 1">s</span> in this repository.
+</p>
+<p class="registry-intro" v-else>
+  No badges have been published yet. Submit one through the <a href="/apply">apply process</a>.
+</p>
+
 <div class="registry-toolbar">
   <RegistryFilters
     :query="query"
@@ -205,6 +213,10 @@ The registry aggregates every badge defined in the repository. Use the filters t
   flex-direction: column;
   gap: 1.25rem;
   margin-bottom: 2rem;
+}
+
+.registry-intro {
+  color: var(--vp-c-text-2);
 }
 
 .sort {

--- a/website/docs/trust.md
+++ b/website/docs/trust.md
@@ -20,7 +20,7 @@ The repository includes a helper script that demonstrates signing and verificati
 ```bash
 python tools/tooling/sign_verify.py verify \
   --public-key website/public/public_key.pem \
-  --badge registry/badge-registry/acme-cloud_cloud-sso_1.0.0.json
+  --badge registry/badge-registry/acme-cloud/cloud-sso/1.0.0.json
 ```
 
 The script reads the badge, canonicalizes it, and verifies the signature against the PEM key. Use it as a reference for your own automation.
@@ -46,7 +46,7 @@ Vendors can publish a signed badge on their sites using JSON-LD:
     "distribution": {
       "@type": "DataDownload",
       "encodingFormat": "application/json",
-      "contentUrl": "https://openauthcert.org/registry/badge-registry/acme-cloud_cloud-sso_1.0.0.json"
+      "contentUrl": "https://openauthcert.org/registry/badge-registry/acme-cloud/cloud-sso/1.0.0.json"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add top-level navigation links for Apply, Governance, and Trust so visitors can reach policy pages quickly
- highlight revocation notes within badge cards to make revoked badge reasoning easier to scan

## Testing
- CI=1 npm run build --prefix website > /tmp/vitepress-build.log 2>&1
- node --import ./website/node_modules/tsx/dist/esm/index.mjs website/scripts/check-registry-build.ts

------
https://chatgpt.com/codex/tasks/task_e_68e8f2100ff48323a663c5781e2e0083