### PR TITLE
Potential fix for code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -159,17 +159,21 @@ export async function buildApp(opts: AppOptions): Promise<FastifyInstance> {
     },
   );
 
-  app.post<{ Body: Badge }>("/verify", async (req) => {
-    const signatureValid = verifyBadge(req.body, pub);
-    const status = effectiveStatus(req.body);
-    // A badge is only "good" if the signature holds AND it currently certifies.
-    return {
-      valid: signatureValid,
-      status,
-      current: signatureValid && status === "certified",
-      expires_at: req.body.expires_at,
-    };
-  });
+  app.post<{ Body: Badge }>(
+    "/verify",
+    { config: { rateLimit: { max: 120, timeWindow: "1 minute" } } },
+    async (req) => {
+      const signatureValid = verifyBadge(req.body, pub);
+      const status = effectiveStatus(req.body);
+      // A badge is only "good" if the signature holds AND it currently certifies.
+      return {
+        valid: signatureValid,
+        status,
+        current: signatureValid && status === "certified",
+        expires_at: req.body.expires_at,
+      };
+    },
+  );
 
   return app;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/openauthcert/openauthcert/security/code-scanning/10](https://github.com/openauthcert/openauthcert/security/code-scanning/10)

Add an explicit per-route rate-limit config to `POST /verify`, similar to other routes that already define route-level limits. This preserves functionality while making protection explicit and satisfying CodeQL.

Best change in `packages/server/src/app.ts`:
- Update the `/verify` route declaration from:
  - `app.post<{ Body: Badge }>("/verify", async (req) => { ... })`
- To:
  - `app.post<{ Body: Badge }>("/verify", { config: { rateLimit: { ... } } }, async (req) => { ... })`

Use limits consistent with read endpoints unless you want stricter values; `max: 120, timeWindow: "1 minute"` is a safe, non-breaking choice here.

No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The `/verify` endpoint now enforces a rate limit of 120 requests per minute.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openauthcert/openauthcert/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->