### PR TITLE
Embeddable click-to-registry badge widget + auto-merge for auto-revoke PRs

### DIFF
--- a/.github/workflows/probe-compliance.yml
+++ b/.github/workflows/probe-compliance.yml
@@ -84,8 +84,16 @@ jobs:
           git config user.email "bot@openauthcert.org"
           git commit -m "Auto-revoke badges failing compliance" || { echo "nothing to revoke"; exit 0; }
           git push -u origin auto-revoke/${{ github.run_id }}
-          gh pr create --base main --head auto-revoke/${{ github.run_id }} \
+          pr_url=$(gh pr create --base main --head auto-revoke/${{ github.run_id }} \
             --title "Auto-revoke: badges failing compliance probe" \
-            --body "The nightly compliance probe found these badges non-compliant for 3 consecutive runs. They have been re-signed as \`revoked\`. Review and merge to publish.
+            --body "The nightly compliance probe found these badges non-compliant for 3 consecutive runs. They have been re-signed as \`revoked\`.
 
-$(cat registry/evidence/revoke-list.json)"
+This PR is set to **auto-merge once required checks pass**.
+
+$(cat registry/evidence/revoke-list.json)")
+          echo "opened $pr_url"
+          # Merge automatically once required checks pass. Requires repo
+          # Settings -> General -> "Allow auto-merge" to be enabled; if it isn't,
+          # this warns and the PR stays open for manual merge.
+          gh pr merge --auto --squash "$pr_url" \
+            || echo "::warning::could not enable auto-merge (is 'Allow auto-merge' enabled?); PR left open"

--- a/packages/core/src/embed.test.ts
+++ b/packages/core/src/embed.test.ts
@@ -14,6 +14,16 @@ describe("embed URLs", () => {
     );
   });
 
+  it("trims many trailing slashes in linear time", () => {
+    const noisy = "https://openauthcert.org" + "/".repeat(5000);
+    expect(statusSvgUrl(badge, noisy)).toBe(
+      "https://openauthcert.org/badges/acme-cloud/cloud-sso/1.0.0.svg",
+    );
+    expect(registryDeepLink(badge, noisy)).toBe(
+      "https://openauthcert.org/registry?vendor=acme-cloud&app=cloud-sso",
+    );
+  });
+
   it("deep-links to the pre-filtered registry", () => {
     expect(registryDeepLink(badge)).toBe(
       "https://openauthcert.org/registry?vendor=acme-cloud&app=cloud-sso",

--- a/packages/core/src/embed.test.ts
+++ b/packages/core/src/embed.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { statusSvgPath, statusSvgUrl, registryDeepLink } from "./embed.js";
+
+const badge = { vendor: "acme-cloud", application: "cloud-sso", version: "1.0.0" };
+
+describe("embed URLs", () => {
+  it("builds the status SVG path", () => {
+    expect(statusSvgPath(badge)).toBe("/badges/acme-cloud/cloud-sso/1.0.0.svg");
+  });
+
+  it("builds an absolute SVG URL and trims trailing slashes", () => {
+    expect(statusSvgUrl(badge, "https://openauthcert.org/")).toBe(
+      "https://openauthcert.org/badges/acme-cloud/cloud-sso/1.0.0.svg",
+    );
+  });
+
+  it("deep-links to the pre-filtered registry", () => {
+    expect(registryDeepLink(badge)).toBe(
+      "https://openauthcert.org/registry?vendor=acme-cloud&app=cloud-sso",
+    );
+  });
+
+  it("encodes unusual segment characters", () => {
+    expect(statusSvgPath({ vendor: "a b", application: "c/d", version: "1.0" })).toBe(
+      "/badges/a%20b/c%2Fd/1.0.svg",
+    );
+  });
+});

--- a/packages/core/src/embed.ts
+++ b/packages/core/src/embed.ts
@@ -7,6 +7,13 @@ import type { Badge } from "./types.js";
 
 type BadgeSlugParts = Pick<Badge, "vendor" | "application" | "version">;
 
+/** Trim trailing slashes in linear time (no regex backtracking on hostile input). */
+function trimTrailingSlashes(url: string): string {
+  let end = url.length;
+  while (end > 0 && url.charCodeAt(end - 1) === 0x2f /* '/' */) end -= 1;
+  return url.slice(0, end);
+}
+
 /** Site-root path of a badge's status SVG, e.g. `/badges/acme/cloud-sso/1.0.0.svg`. */
 export function statusSvgPath(b: BadgeSlugParts): string {
   return `/badges/${encodeURIComponent(b.vendor)}/${encodeURIComponent(
@@ -23,7 +30,7 @@ export function registryDeepLink(
   b: Pick<Badge, "vendor" | "application">,
   siteUrl = "https://openauthcert.org",
 ): string {
-  const base = siteUrl.replace(/\/+$/, "");
+  const base = trimTrailingSlashes(siteUrl);
   const q = new URLSearchParams({ vendor: b.vendor, app: b.application });
   return `${base}/registry?${q.toString()}`;
 }
@@ -33,5 +40,5 @@ export function statusSvgUrl(
   b: BadgeSlugParts,
   siteUrl = "https://openauthcert.org",
 ): string {
-  return `${siteUrl.replace(/\/+$/, "")}${statusSvgPath(b)}`;
+  return `${trimTrailingSlashes(siteUrl)}${statusSvgPath(b)}`;
 }

--- a/packages/core/src/embed.ts
+++ b/packages/core/src/embed.ts
@@ -1,0 +1,37 @@
+/**
+ * Embed URL helpers for the status badge / click-to-registry widget. Pure —
+ * safe to import in the browser. Kept in core so the website components and the
+ * standalone embed.js (which mirrors these strings) stay consistent.
+ */
+import type { Badge } from "./types.js";
+
+type BadgeSlugParts = Pick<Badge, "vendor" | "application" | "version">;
+
+/** Site-root path of a badge's status SVG, e.g. `/badges/acme/cloud-sso/1.0.0.svg`. */
+export function statusSvgPath(b: BadgeSlugParts): string {
+  return `/badges/${encodeURIComponent(b.vendor)}/${encodeURIComponent(
+    b.application,
+  )}/${encodeURIComponent(b.version)}.svg`;
+}
+
+/**
+ * Deep link to the registry pre-filtered to this badge's vendor + application.
+ * The registry page hydrates these query params on load (RegistryFilters runs
+ * its route watcher with `immediate: true`).
+ */
+export function registryDeepLink(
+  b: Pick<Badge, "vendor" | "application">,
+  siteUrl = "https://openauthcert.org",
+): string {
+  const base = siteUrl.replace(/\/+$/, "");
+  const q = new URLSearchParams({ vendor: b.vendor, app: b.application });
+  return `${base}/registry?${q.toString()}`;
+}
+
+/** Absolute URL of a badge's status SVG. */
+export function statusSvgUrl(
+  b: BadgeSlugParts,
+  siteUrl = "https://openauthcert.org",
+): string {
+  return `${siteUrl.replace(/\/+$/, "")}${statusSvgPath(b)}`;
+}

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -7,3 +7,4 @@
 export * from "./canonicalize.js";
 export * from "./types.js";
 export * from "./status.js";
+export * from "./embed.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,5 +2,6 @@
 export * from "./canonicalize.js";
 export * from "./types.js";
 export * from "./status.js";
+export * from "./embed.js";
 export * from "./schema.js";
 export * from "./crypto-node.js";

--- a/website/docs/.vitepress/theme/components/BadgeCard.vue
+++ b/website/docs/.vitepress/theme/components/BadgeCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { statusSvgUrl, registryDeepLink } from '@openauthcert/core/browser'
 import type { Badge } from '../../registry'
 
 const props = defineProps<{ badge: Badge }>()
@@ -14,14 +15,21 @@ const revoked = computed(() =>
 )
 
 const siteUrl = 'https://openauthcert.org'
-const badgeImg = computed(
-  () => `${siteUrl}/badges/${props.badge.vendor}/${props.badge.application}/${props.badge.version}.svg`
-)
+const badgeImg = computed(() => statusSvgUrl(props.badge, siteUrl))
+const registryUrl = computed(() => registryDeepLink(props.badge, siteUrl))
 const embedMarkdown = computed(
-  () => `[![OpenAuthCert](${badgeImg.value})](${siteUrl}/registry)`
+  () => `[![OpenAuthCert](${badgeImg.value})](${registryUrl.value})`
 )
 const embedHtml = computed(
-  () => `<a href="${siteUrl}/registry"><img src="${badgeImg.value}" alt="OpenAuthCert status"></a>`
+  () => `<a href="${registryUrl.value}"><img src="${badgeImg.value}" alt="OpenAuthCert status"></a>`
+)
+const widgetSnippet = computed(
+  () =>
+    `<div data-openauthcert\n` +
+    `     data-vendor="${props.badge.vendor}"\n` +
+    `     data-application="${props.badge.application}"\n` +
+    `     data-version="${props.badge.version}"></div>\n` +
+    `<script src="${siteUrl}/embed.js" async><\/script>`
 )
 
 function formatDate(value: string) {
@@ -82,6 +90,8 @@ function formatDate(value: string) {
       <pre><code>{{ embedMarkdown }}</code></pre>
       <label>HTML</label>
       <pre><code>{{ embedHtml }}</code></pre>
+      <label>Clickable widget (JS)</label>
+      <pre><code>{{ widgetSnippet }}</code></pre>
     </details>
     <slot />
   </article>

--- a/website/docs/apply.md
+++ b/website/docs/apply.md
@@ -41,8 +41,26 @@ Optional but recommended fields:
 A badge is a point-in-time attestation, so it does not last forever:
 
 - **Renewal** – certifications are valid for 12 months (`expires_at`). After that the badge shows as **expired** until you submit a renewal PR for re-validation.
-- **Continuous checks** – a nightly probe re-tests the URLs in your `checks` block. If the certified feature disappears or moves behind a paywall for **three consecutive days**, the badge is automatically re-signed as **revoked**. See [Governance](/governance).
-- **Embed a live badge** – each registry entry offers a copy-paste *status* image (`https://openauthcert.org/badges/<vendor>/<application>/<version>.svg`). It reflects current status, so it flips to *expired* or *revoked* on its own — no stale "certified" graphics on your site.
+- **Continuous checks** – a nightly probe re-tests the URLs in your `checks` block. If the certified feature disappears or moves behind a paywall for **three consecutive probe runs**, the badge is automatically re-signed as **revoked**. See [Governance](/governance).
+
+## Show your badge
+
+Every registry entry has an **Embed this badge** panel with copy-paste snippets. All three render the same live status image (regenerated on openauthcert.org, so it flips to *expired* or *revoked* on its own — no stale "certified" graphics on your site):
+
+- **Markdown / HTML image** – links to your filtered registry entry:
+  ```html
+  <a href="https://openauthcert.org/registry?vendor=<vendor>&app=<application>"><img src="https://openauthcert.org/badges/<vendor>/<application>/<version>.svg" alt="OpenAuthCert status"></a>
+  ```
+- **Clickable JS widget** – drop in a placeholder + one script tag; clicking the badge opens your entry in the registry:
+  ```html
+  <div data-openauthcert
+       data-vendor="<vendor>"
+       data-application="<application>"
+       data-version="<version>"></div>
+  <script src="https://openauthcert.org/embed.js" async></script>
+  ```
+
+The widget makes no external calls beyond loading the badge image, sets no cookies, and does no tracking.
 
 ## 2. Add supporting evidence
 

--- a/website/docs/public/embed.js
+++ b/website/docs/public/embed.js
@@ -53,8 +53,15 @@
     return { vendor: vendor, application: application, version: version };
   }
 
+  // Trim trailing slashes in linear time (no regex backtracking).
+  function trimTrailingSlashes(s) {
+    var end = s.length;
+    while (end > 0 && s.charCodeAt(end - 1) === 0x2f /* '/' */) end -= 1;
+    return s.slice(0, end);
+  }
+
   function urlsFor(cfg, site) {
-    var base = (site || DEFAULT_SITE).replace(/\/+$/, "");
+    var base = trimTrailingSlashes(site || DEFAULT_SITE);
     var v = encodeURIComponent(cfg.vendor);
     var a = encodeURIComponent(cfg.application);
     var ver = encodeURIComponent(cfg.version);

--- a/website/docs/public/embed.js
+++ b/website/docs/public/embed.js
@@ -1,0 +1,121 @@
+/*!
+ * OpenAuthCert embed widget — https://openauthcert.org/embed.js
+ *
+ * Renders a vendor's live status badge that links to their entry in the
+ * registry. Drop this on any page:
+ *
+ *   <div data-openauthcert
+ *        data-vendor="acme-cloud"
+ *        data-application="cloud-sso"
+ *        data-version="1.0.0"></div>
+ *   <script src="https://openauthcert.org/embed.js" async></script>
+ *
+ * Or with a single slug: <div data-openauthcert data-badge="acme-cloud/cloud-sso/1.0.0"></div>
+ *
+ * The badge image is generated/refreshed on openauthcert.org, so it flips to
+ * "expired" or "revoked" on its own. Clicking it opens the registry filtered to
+ * that vendor + application. No tracking, no cookies, no external calls beyond
+ * loading the badge image from openauthcert.org.
+ *
+ * URL logic mirrors `@openauthcert/core` (statusSvgPath / registryDeepLink).
+ */
+(function () {
+  "use strict";
+
+  var DEFAULT_SITE = "https://openauthcert.org";
+
+  // Resolve the site origin from this script's own src so the widget works on
+  // staging/preview hosts too; fall back to the production domain.
+  function siteOrigin() {
+    try {
+      var cur = document.currentScript;
+      if (cur && cur.src) return new URL(cur.src).origin;
+    } catch (e) {
+      /* ignore */
+    }
+    return DEFAULT_SITE;
+  }
+
+  function parseConfig(el) {
+    var vendor = el.getAttribute("data-vendor");
+    var application = el.getAttribute("data-application");
+    var version = el.getAttribute("data-version");
+    var badge = el.getAttribute("data-badge");
+    if ((!vendor || !application || !version) && badge) {
+      var parts = badge.split("/");
+      if (parts.length === 3) {
+        vendor = vendor || parts[0];
+        application = application || parts[1];
+        version = version || parts[2];
+      }
+    }
+    if (!vendor || !application || !version) return null;
+    return { vendor: vendor, application: application, version: version };
+  }
+
+  function urlsFor(cfg, site) {
+    var base = (site || DEFAULT_SITE).replace(/\/+$/, "");
+    var v = encodeURIComponent(cfg.vendor);
+    var a = encodeURIComponent(cfg.application);
+    var ver = encodeURIComponent(cfg.version);
+    return {
+      img: base + "/badges/" + v + "/" + a + "/" + ver + ".svg",
+      link: base + "/registry?vendor=" + v + "&app=" + a,
+    };
+  }
+
+  function render(el, site) {
+    if (!el || el.getAttribute("data-openauthcert-rendered") === "1") return;
+    var cfg = parseConfig(el);
+    if (!cfg) return;
+    var urls = urlsFor(cfg, site);
+
+    var a = document.createElement("a");
+    a.href = urls.link;
+    a.target = "_blank";
+    a.rel = "noopener noreferrer";
+    a.className = "openauthcert-badge-link";
+    a.setAttribute(
+      "aria-label",
+      "OpenAuthCert certification status for " +
+        cfg.vendor +
+        "/" +
+        cfg.application +
+        " — opens the registry",
+    );
+
+    var img = document.createElement("img");
+    img.src = urls.img;
+    img.alt = "OpenAuthCert: " + cfg.vendor + "/" + cfg.application + " status";
+    img.height = 20;
+    img.loading = "lazy";
+    img.style.verticalAlign = "middle";
+
+    a.appendChild(img);
+    el.appendChild(a);
+    el.setAttribute("data-openauthcert-rendered", "1");
+  }
+
+  function renderAll(root) {
+    var site = siteOrigin();
+    var nodes = (root || document).querySelectorAll(
+      "[data-openauthcert], .openauthcert-badge",
+    );
+    for (var i = 0; i < nodes.length; i++) render(nodes[i], site);
+  }
+
+  // Public surface (also enables headless testing).
+  var api = { render: render, renderAll: renderAll, urlsFor: urlsFor };
+  if (typeof globalThis !== "undefined") globalThis.OpenAuthCert = api;
+
+  // Auto-run in the browser only.
+  if (typeof document !== "undefined") {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", function () {
+        renderAll();
+      });
+    } else {
+      renderAll();
+    }
+  }
+})();


### PR DESCRIPTION
## What

Two follow-ups from the lifecycle work.

### 1. Click-to-registry embed widget
Vendors can now drop a live, clickable certification badge on their site that opens their entry in the registry.

```html
<div data-openauthcert
     data-vendor="acme-cloud"
     data-application="cloud-sso"
     data-version="1.0.0"></div>
<script src="https://openauthcert.org/embed.js" async></script>
```

- **`website/docs/public/embed.js`** — standalone, dependency-free vanilla JS. Scans for `[data-openauthcert]` placeholders and injects a status `<img>` wrapped in a link to `/registry?vendor=…&app=…` (which **pre-filters on load** — the `RegistryFilters` route watcher runs with `immediate: true`). No cookies, no tracking, no network calls beyond loading the badge image. Resolves the site origin from its own `<script src>` so it works on preview hosts too.
- **`@openauthcert/core`** — pure, tested URL helpers `statusSvgPath` / `statusSvgUrl` / `registryDeepLink`, exported to Node and the browser bundle.
- **`BadgeCard`** — the existing image snippets now deep-link to the filtered registry, and a third **"Clickable widget (JS)"** snippet is offered. Uses the core helpers.
- **`apply.md`** — a "Show your badge" section documents the image and widget options.

On the **"uuid"** you mentioned: the unique identifier here is the `vendor/application/version` slug (used in the data attributes / `data-badge="vendor/app/version"`). Opaque UUIDs would mean adding a signed field and re-signing every badge — happy to do that as a follow-up if you'd prefer real UUIDs.

I also **couldn't open the image** you attached ("problem: see above"). If it flagged a specific issue with the embed approach, share the detail and I'll fold it in.

### 2. Auto-merge the auto-revoke PRs
`probe-compliance.yml` now runs `gh pr merge --auto --squash` on the revocation PR, so it merges itself once required checks pass (it warns and leaves the PR open if repo auto-merge is disabled).
**Action needed on your side:** enable **Settings → General → Allow auto-merge**, and keep branch protection with required checks on `main` so the auto-merge actually waits for green CI.

## Verification
- **38 unit tests pass** (core 21 incl. new embed-URL tests, cli 10, server 7).
- Headless DOM smoke test of `embed.js`: injects `<a href=".../registry?vendor=acme-cloud&app=cloud-sso">`&lt;img src=".../badges/acme-cloud/cloud-sso/1.0.0.svg"&gt;`` and marks the node rendered.
- `vitepress build` ships `/embed.js` to the site root; `oac validate` green; `node --check embed.js` clean; lockfile unchanged (no new deps).

https://claude.ai/code/session_01WzcvJyBmXpsL34VWkzbAcL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzcvJyBmXpsL34VWkzbAcL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embeddable OpenAuthCert badges with clickable JavaScript widgets.
  * Badge embeds now link directly to the relevant filtered registry entry.
  * Added shared helpers for generating badge image and registry URLs.
  * Added browser support for rendering badges from simple HTML attributes or badge slugs.
  * Auto-revocation pull requests now clearly indicate that auto-merge begins after required checks pass.

* **Documentation**
  * Updated badge embedding instructions, widget behavior, privacy details, and revocation timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->